### PR TITLE
NG-1068 Use different variable to track if external devices are detected

### DIFF
--- a/android/src/main/java/com/media4care/twilio/video/TwilioVideoActivity.java
+++ b/android/src/main/java/com/media4care/twilio/video/TwilioVideoActivity.java
@@ -453,7 +453,7 @@ public class TwilioVideoActivity extends AppCompatActivity {
 
         AudioDeviceInfo[] nativeDevices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
 
-        isExternalDeviceConnected = false;
+        boolean isExternalDeviceDetected = false;
 
         for (AudioDeviceInfo device : nativeDevices) {
             int t = device.getType();
@@ -462,7 +462,7 @@ public class TwilioVideoActivity extends AppCompatActivity {
                 t != AudioDeviceInfo.TYPE_BUILTIN_SPEAKER &&
                 t != AudioDeviceInfo.TYPE_TELEPHONY
             ) {
-                isExternalDeviceConnected = true;
+                isExternalDeviceDetected = true;
                 break;
             }
         }
@@ -474,7 +474,7 @@ public class TwilioVideoActivity extends AppCompatActivity {
             Log.e(TAG, "unable to start audio switch");
         }
 
-        if (!isExternalDeviceConnected && audioSwitch.getSelectedAudioDevice() instanceof AudioDevice.Earpiece) selectSpeakerAsAudioOutput();
+        if (!isExternalDeviceDetected && audioSwitch.getSelectedAudioDevice() instanceof AudioDevice.Earpiece) selectSpeakerAsAudioOutput();
 
     }
 


### PR DESCRIPTION
It takes a while for audioSwitch to detect external devices so its better
to enable speaker as default device only if no external devices were detected
using android AudioManager api